### PR TITLE
Add Zig implementation

### DIFF
--- a/zig/.gitignore
+++ b/zig/.gitignore
@@ -1,0 +1,1 @@
+zig-cache/

--- a/zig/Makefile
+++ b/zig/Makefile
@@ -1,2 +1,5 @@
 v1:
 	zig build -Drelease-fast
+
+v2:
+	zig build -Drelease-fast -DbufferedIo

--- a/zig/Makefile
+++ b/zig/Makefile
@@ -1,0 +1,2 @@
+v1:
+	zig build -Drelease-fast

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1,0 +1,24 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
+    const mode = b.standardReleaseOptions();
+
+    const exe = b.addExecutable("app", "src/main.zig");
+    exe.setTarget(target);
+    exe.setBuildMode(mode);
+    exe.install();
+
+    const run_cmd = exe.run();
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -11,10 +11,18 @@ pub fn build(b: *Builder) void {
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const mode = b.standardReleaseOptions();
 
+    const bufferedIo = b.option(
+        bool,
+        "bufferedIo",
+        "Set to true to use buffered IO for output",
+    ) orelse false;
+
     const exe = b.addExecutable("app", "src/main.zig");
     exe.setTarget(target);
     exe.setBuildMode(mode);
     exe.install();
+
+    exe.addBuildOption(bool, "bufferedIo", bufferedIo);
 
     const run_cmd = exe.run();
     run_cmd.step.dependOn(b.getInstallStep());

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -1,10 +1,9 @@
 const std = @import("std");
 const pow = std.math.pow;
+const build_options = @import("build_options");
 
 const N: u32 = 440_000_000;
-const cache = getCache();
-
-fn getCache() [10]u32 {
+const cache = init: {
     var result: [10]u32 = undefined;
 
     result[0] = 0;
@@ -13,8 +12,8 @@ fn getCache() [10]u32 {
         result[i] = pow(u32, i, i);
     }
 
-    return result;
-}
+    break :init result;
+};
 
 fn isMunchausen(number: u32) bool {
     var n = number;
@@ -35,17 +34,20 @@ fn isMunchausen(number: u32) bool {
 }
 
 pub fn main() anyerror!void {
-    const stdout = std.io.getStdOut().outStream();
+    const output = if (build_options.bufferedIo)
+        std.io.bufferedOutStream(std.io.getStdOut().outStream()).outStream()
+    else
+        std.io.getStdOut().outStream();
 
     var n: u32 = 0;
 
     while (n < N) : (n += 1) {
         if (n > 0 and n % 1_000_000 == 0) {
-            try stdout.print("# {}\n", .{n});
+            try output.print("# {}\n", .{n});
         }
 
         if (isMunchausen(n)) {
-            try stdout.print("{}\n", .{n});
+            try output.print("{}\n", .{n});
         }
     }
 }

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const pow = std.math.pow;
+
+const N: u32 = 440_000_000;
+const cache = getCache();
+
+fn getCache() [10]u32 {
+    var result: [10]u32 = undefined;
+
+    result[0] = 0;
+    var i: u32 = 1;
+    while (i < 10) : (i += 1) {
+        result[i] = pow(u32, i, i);
+    }
+
+    return result;
+}
+
+fn isMunchausen(number: u32) bool {
+    var n = number;
+    var total: u32 = 0;
+
+    while (n > 0) {
+        const digit = n % 10;
+        total += cache[digit];
+
+        if (total > number) {
+            return false;
+        }
+
+        n = n / 10;
+    }
+
+    return total == number;
+}
+
+pub fn main() anyerror!void {
+    const stdout = std.io.getStdOut().outStream();
+
+    var n: u32 = 0;
+
+    while (n < N) : (n += 1) {
+        if (n > 0 and n % 1_000_000 == 0) {
+            try stdout.print("# {}\n", .{n});
+        }
+
+        if (isMunchausen(n)) {
+            try stdout.print("{}\n", .{n});
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an implementation in [Zig](https://ziglang.org).

Output of running:

<details>

```
0
1
3435
# 1000000
# 2000000
# 3000000
# 4000000
# 5000000
# 6000000
# 7000000
# 8000000
# 9000000
# 10000000
# 11000000
# 12000000
# 13000000
# 14000000
# 15000000
# 16000000
# 17000000
# 18000000
# 19000000
# 20000000
# 21000000
# 22000000
# 23000000
# 24000000
# 25000000
# 26000000
# 27000000
# 28000000
# 29000000
# 30000000
# 31000000
# 32000000
# 33000000
# 34000000
# 35000000
# 36000000
# 37000000
# 38000000
# 39000000
# 40000000
# 41000000
# 42000000
# 43000000
# 44000000
# 45000000
# 46000000
# 47000000
# 48000000
# 49000000
# 50000000
# 51000000
# 52000000
# 53000000
# 54000000
# 55000000
# 56000000
# 57000000
# 58000000
# 59000000
# 60000000
# 61000000
# 62000000
# 63000000
# 64000000
# 65000000
# 66000000
# 67000000
# 68000000
# 69000000
# 70000000
# 71000000
# 72000000
# 73000000
# 74000000
# 75000000
# 76000000
# 77000000
# 78000000
# 79000000
# 80000000
# 81000000
# 82000000
# 83000000
# 84000000
# 85000000
# 86000000
# 87000000
# 88000000
# 89000000
# 90000000
# 91000000
# 92000000
# 93000000
# 94000000
# 95000000
# 96000000
# 97000000
# 98000000
# 99000000
# 100000000
# 101000000
# 102000000
# 103000000
# 104000000
# 105000000
# 106000000
# 107000000
# 108000000
# 109000000
# 110000000
# 111000000
# 112000000
# 113000000
# 114000000
# 115000000
# 116000000
# 117000000
# 118000000
# 119000000
# 120000000
# 121000000
# 122000000
# 123000000
# 124000000
# 125000000
# 126000000
# 127000000
# 128000000
# 129000000
# 130000000
# 131000000
# 132000000
# 133000000
# 134000000
# 135000000
# 136000000
# 137000000
# 138000000
# 139000000
# 140000000
# 141000000
# 142000000
# 143000000
# 144000000
# 145000000
# 146000000
# 147000000
# 148000000
# 149000000
# 150000000
# 151000000
# 152000000
# 153000000
# 154000000
# 155000000
# 156000000
# 157000000
# 158000000
# 159000000
# 160000000
# 161000000
# 162000000
# 163000000
# 164000000
# 165000000
# 166000000
# 167000000
# 168000000
# 169000000
# 170000000
# 171000000
# 172000000
# 173000000
# 174000000
# 175000000
# 176000000
# 177000000
# 178000000
# 179000000
# 180000000
# 181000000
# 182000000
# 183000000
# 184000000
# 185000000
# 186000000
# 187000000
# 188000000
# 189000000
# 190000000
# 191000000
# 192000000
# 193000000
# 194000000
# 195000000
# 196000000
# 197000000
# 198000000
# 199000000
# 200000000
# 201000000
# 202000000
# 203000000
# 204000000
# 205000000
# 206000000
# 207000000
# 208000000
# 209000000
# 210000000
# 211000000
# 212000000
# 213000000
# 214000000
# 215000000
# 216000000
# 217000000
# 218000000
# 219000000
# 220000000
# 221000000
# 222000000
# 223000000
# 224000000
# 225000000
# 226000000
# 227000000
# 228000000
# 229000000
# 230000000
# 231000000
# 232000000
# 233000000
# 234000000
# 235000000
# 236000000
# 237000000
# 238000000
# 239000000
# 240000000
# 241000000
# 242000000
# 243000000
# 244000000
# 245000000
# 246000000
# 247000000
# 248000000
# 249000000
# 250000000
# 251000000
# 252000000
# 253000000
# 254000000
# 255000000
# 256000000
# 257000000
# 258000000
# 259000000
# 260000000
# 261000000
# 262000000
# 263000000
# 264000000
# 265000000
# 266000000
# 267000000
# 268000000
# 269000000
# 270000000
# 271000000
# 272000000
# 273000000
# 274000000
# 275000000
# 276000000
# 277000000
# 278000000
# 279000000
# 280000000
# 281000000
# 282000000
# 283000000
# 284000000
# 285000000
# 286000000
# 287000000
# 288000000
# 289000000
# 290000000
# 291000000
# 292000000
# 293000000
# 294000000
# 295000000
# 296000000
# 297000000
# 298000000
# 299000000
# 300000000
# 301000000
# 302000000
# 303000000
# 304000000
# 305000000
# 306000000
# 307000000
# 308000000
# 309000000
# 310000000
# 311000000
# 312000000
# 313000000
# 314000000
# 315000000
# 316000000
# 317000000
# 318000000
# 319000000
# 320000000
# 321000000
# 322000000
# 323000000
# 324000000
# 325000000
# 326000000
# 327000000
# 328000000
# 329000000
# 330000000
# 331000000
# 332000000
# 333000000
# 334000000
# 335000000
# 336000000
# 337000000
# 338000000
# 339000000
# 340000000
# 341000000
# 342000000
# 343000000
# 344000000
# 345000000
# 346000000
# 347000000
# 348000000
# 349000000
# 350000000
# 351000000
# 352000000
# 353000000
# 354000000
# 355000000
# 356000000
# 357000000
# 358000000
# 359000000
# 360000000
# 361000000
# 362000000
# 363000000
# 364000000
# 365000000
# 366000000
# 367000000
# 368000000
# 369000000
# 370000000
# 371000000
# 372000000
# 373000000
# 374000000
# 375000000
# 376000000
# 377000000
# 378000000
# 379000000
# 380000000
# 381000000
# 382000000
# 383000000
# 384000000
# 385000000
# 386000000
# 387000000
# 388000000
# 389000000
# 390000000
# 391000000
# 392000000
# 393000000
# 394000000
# 395000000
# 396000000
# 397000000
# 398000000
# 399000000
# 400000000
# 401000000
# 402000000
# 403000000
# 404000000
# 405000000
# 406000000
# 407000000
# 408000000
# 409000000
# 410000000
# 411000000
# 412000000
# 413000000
# 414000000
# 415000000
# 416000000
# 417000000
# 418000000
# 419000000
# 420000000
# 421000000
# 422000000
# 423000000
# 424000000
# 425000000
# 426000000
# 427000000
# 428000000
# 429000000
# 430000000
# 431000000
# 432000000
# 433000000
# 434000000
# 435000000
# 436000000
# 437000000
# 438000000
438579088
# 439000000
```
</details>

Timing (from my machine - macOS, Intel i7-9750H CPU @ 2.60GHz)

**C:**

```
> make v6
clang -Ofast main.c -o main -lm
> /usr/bin/time -l ./main
...
        3.36 real         3.34 user         0.01 sys
    741376  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
       202  page reclaims
         0  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         0  voluntary context switches
      1131  involuntary context switches
```

**Zig:**

```
> make v1
zig build -Drelease-fast
> /usr/bin/time -l ./zig-cache/bin/app
...
        2.99 real         2.97 user         0.01 sys
    729088  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
       198  page reclaims
         0  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         0  voluntary context switches
       867  involuntary context switches
```

---------------

There are two Zig versions, controlled by a build option. one uses buffered IO, the other does not.

Results on my system between the two:

**Unbuffered:**

```
        2.62 real         2.61 user         0.00 sys
    729088  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
       200  page reclaims
         0  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         0  voluntary context switches
       196  involuntary context switches
```

**Buffered:**

```
        2.49 real         2.49 user         0.00 sys
    729088  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
       199  page reclaims
         0  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         4  voluntary context switches
        74  involuntary context switches
```