### PR TITLE
Use sized integers for Nim

### DIFF
--- a/nim/main.nim
+++ b/nim/main.nim
@@ -1,18 +1,18 @@
 import math
 
-func get_cache(): array[10, int] =
+func get_cache(): array[10, uint32] =
   result[0] = 0
-  for i in 1 .. 9:
+  for i in 1'u32 .. 9'u32:
     result[i] = i ^ i
 
 const
-  MAX = 440_000_000
-  cache: array[10, int] = get_cache()
+  MAX: uint32 = 440_000_000
+  cache: array[10, uint32] = get_cache()
 
-func is_munchausen(number: int): bool =
+func is_munchausen(number: uint32): bool =
   var
     n = number
-    total = 0
+    total: uint32 = 0
 
   while n > 0:
     let digit = n mod 10
@@ -24,7 +24,7 @@ func is_munchausen(number: int): bool =
   total == number
 
 proc main() =
-  for i in 0 ..< MAX:
+  for i in 0'u32 ..< MAX:
     if is_munchausen(i):
       echo i
 


### PR DESCRIPTION
Altered Nim code to use `uint32` for integer values, to match other implementations (e.g. Rust, Zig).

In Nim, the size of `int` is platform dependent (e.g. 64 bits on 64 bit systems, and 32 bits on 32 bit systems).