### PR TITLE
Add vectorized c code

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,11 +1,26 @@
+all:v1 v2 v1-native v2-native v3-native
+
 v1:
-	gcc -O2 main.c -o main -lm
+	gcc -O2 main.c -o $@ -lm
 
 v2:
-	clang -O2 main.c -o main -lm
+	clang -O2 main.c -o $@ -lm
+
+v1-native:
+	gcc -O3 main.c -o $@ -lm -march=native
+
+v2-native:
+	clang -O2 main.c -o $@ -lm -march=native
+
+v3-native:
+	gcc -O3 main_v3.c -o $@ -lm -march=native
 
 strip:
-	strip -s main
+	strip -s v1
+	strip -s v2
+	strip -s v1-native
+	strip -s v2-native
+	strip -s v3-native
 
 clean:
-	rm main
+	rm v1 v2 v1-native v2-native v3-native

--- a/c/main_v3.c
+++ b/c/main_v3.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <math.h>
+#include <stdbool.h>
+
+#define MAX 440000000
+#define M 32
+
+int cache[10];
+
+void is_munchausen(const int number,int b[M])
+{
+    int n[M];
+    int total[M];
+    for(int j=0;j<M;j++){
+        n[j] = number + j;
+        total[j] = 0;
+    }
+    for(int j=0;j<M;j++)
+        total[j] += cache[n[j] % 10];
+    for(int i=1;i<9;i++){
+        for(int j=0;j<M;j++)
+            n[j] /= 10;
+        for(int j=0;j<M;j++)
+            total[j] += cache[n[j] % 10];
+    }
+    for(int j=0;j<M;j++)
+        b[j] = (number + j) == total[j];
+}
+
+void set_cache()
+{
+    cache[0] = 0;
+    for (int i = 1; i <= 9; ++i) {
+        cache[i] = pow(i, i);
+    }
+}
+
+int main()
+{
+    int b[M];
+    set_cache();
+
+    for (int i = 0; i < MAX; i+=M)
+    {
+        is_munchausen(i,b);
+        for(int j=0;j<M;j++)
+        {
+            if(b[j])
+            {
+                printf("%d\n",i+j);
+            }
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR speeds up c implementation with SIMD.
The compiler of c-lang has the feature of auto-vectorization.

The result is below.  The program of `v3-native` uses SIMD.

```
$ grep "model name" /proc/cpuinfo | head -1
model name      : Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
$ gcc --version
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
$ clang --version
clang version 10.0.0-4ubuntu1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
$ hyperfine --warmup 2  -m 3 ./v1 ./v2 ./v1-native ./v2-native ./v3-native
Benchmark #1: ./v1
  Time (mean ± σ):      3.523 s ±  0.033 s    [User: 3.522 s, System: 0.001 s]
  Range (min … max):    3.500 s …  3.561 s    3 runs

Benchmark #2: ./v2
  Time (mean ± σ):      2.364 s ±  0.035 s    [User: 2.364 s, System: 0.000 s]
  Range (min … max):    2.332 s …  2.401 s    3 runs

Benchmark #3: ./v1-native
  Time (mean ± σ):      3.532 s ±  0.035 s    [User: 3.532 s, System: 0.000 s]
  Range (min … max):    3.493 s …  3.558 s    3 runs

Benchmark #4: ./v2-native
  Time (mean ± σ):      2.290 s ±  0.022 s    [User: 2.290 s, System: 0.000 s]
  Range (min … max):    2.275 s …  2.315 s    3 runs

Benchmark #5: ./v3-native
  Time (mean ± σ):      1.463 s ±  0.010 s    [User: 1.463 s, System: 0.000 s]
  Range (min … max):    1.456 s …  1.474 s    3 runs

Summary
  './v3-native' ran
    1.57 ± 0.02 times faster than './v2-native'
    1.62 ± 0.03 times faster than './v2'
    2.41 ± 0.03 times faster than './v1'
    2.41 ± 0.03 times faster than './v1-native'
```