### PR TITLE
improve Julia runtime

### DIFF
--- a/julia/main.jl
+++ b/julia/main.jl
@@ -25,7 +25,7 @@ end
 function main(N)
     cache = get_cache()
 
-    Threads.@threads for n in 0:N
+    for n in 0:N
         if is_munchausen(n, cache)
             println(n)
         end


### PR DESCRIPTION
This reduces the total wall time on my system from 35 second to 3.7 seconds. The main problem by far was that you were accessing a global variable `N` in a tight loop, but since global variables can change unpredictably, the loop cannot be optimized. 

Hence, I changed the function to accept `N` as an arguments so that inside the function body more assumptions can be. made about it.
```julia
mason@Masons-MacBook-Pro ~ % time julia script.jl
0
1
3435
438579088
julia  script.jl  3.94s user 0.15s system 103% cpu 3.690 total
```

Global variables in Julia are generally bad.