### PR TITLE
Update main.jl

### DIFF
--- a/julia/main.jl
+++ b/julia/main.jl
@@ -1,6 +1,6 @@
 #!/usr/bin/env julia
 
-N = 440_000_000
+const N = 440_000_000
 
 get_cache() = ntuple(i -> i^i, 9)
 


### PR DESCRIPTION
use global constant for type stability. Also is the timing in `README` not updated? It runs ~4 seconds on a 4-yr old Intel U series CPU laptop.