### PR TITLE
Improve the performance with over 20% for Go by using uint

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -7,34 +7,30 @@ import (
 
 const MAX = 440_000_000
 
-func get_cache() [10]int {
-	var result [10]int
-	result[0] = 0
+func get_cache() [10]uint32 {
+	var result [10]uint32
 	for i := 1; i <= 9; i++ {
-		result[i] = int(math.Pow(float64(i), float64(i)))
+		result[i] = uint32(math.Pow(float64(i), float64(i)))
 	}
 	return result
 }
 
-func is_munchausen(number int, cache *[10]int) bool {
+func is_munchausen(number uint, cache *[10]uint32) bool {
 	n := number
-	total := 0
-
+	var total uint
 	for n > 0 {
-		digit := n % 10
-		total += cache[digit]
+		total += uint(cache[n%10])
 		if total > number {
 			return false
 		}
-		n = n / 10
+		n /= 10
 	}
-
 	return total == number
 }
 
 func main() {
 	cache := get_cache()
-	for i := 0; i < MAX; i++ {
+	for i := uint(0); i < MAX; i++ {
 		if is_munchausen(i, &cache) {
 			fmt.Println(i)
 		}


### PR DESCRIPTION
Hopefully, using uint and uint32 are within the rules (I could not find any particular rules for the program in README.md).

Here is the new benchmark result:

```
❯ hyperfine -w 1 -r 2 ./main
Benchmark 1: ./main
  Time (mean ± σ):      1.665 s ±  0.023 s    [User: 1.655 s, System: 0.004 s]
  Range (min … max):    1.649 s …  1.681 s    2 runs
```

Compared to previously:

```
❯ hyperfine -w 1 -r 2 ./main
Benchmark 1: ./main
  Time (mean ± σ):      2.150 s ±  0.014 s    [User: 2.139 s, System: 0.005 s]
  Range (min … max):    2.140 s …  2.160 s    2 runs
```

Also, `result[0] = 0` is not needed, since arrays are initialized to have 0 values in Go.