### PR TITLE
Update the Makefile for the go example + remove go.mod

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -1,18 +1,17 @@
-init:
-	go mod init main
+.PHONY: clean strip
 
-v1:
-	# using int, see v1 in Makefile
-	cp main_v1 main.go
-	go build -o main
+main: main.go
+	go build -o $@ $<
 
-v2:
-	# using uint and uint32, see v2 in Makefile
-	cp main_v2 main.go
-	go build -o main
+v%: main_v%
+	cp -i main_v$* main.go
+	go build -o main main.go
 
-strip:
-	strip -s main
+bench: main
+	hyperfine -w 1 -r 2 ./main
+
+strip: main
+	strip -s $<
 
 clean:
-	rm main
+	rm -f main

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,0 @@
-module main
-
-go 1.17


### PR DESCRIPTION
* Update the `Makefile` so that `go.mod` is no longer needed.
* Remove `go.mod`.
* Update the `Makefile` so that it can handle `main_v1`, `main_v2`, `main_v3` etc. without needing specific make targets.
* Add `make bench` that uses `hyperfine`.