### PR TITLE
Add Scala3 implementation

### DIFF
--- a/scala3/.gitignore
+++ b/scala3/.gitignore
@@ -1,0 +1,3 @@
+main.jar
+.bsp
+.scala-build

--- a/scala3/Makefile
+++ b/scala3/Makefile
@@ -1,0 +1,8 @@
+v1:
+	scalac main.scala -d main.jar
+
+run1:
+	scala main.jar
+
+clean:
+	rm -rf .bsp .scala-build main.jar

--- a/scala3/main.scala
+++ b/scala3/main.scala
@@ -1,0 +1,22 @@
+import scala.math.pow
+
+@annotation.tailrec
+def isMunchausen(number: Int, n: Int, total: Int, cache: Array[Int]): Boolean =
+    if total > number then
+        false
+    else if n > 0 then
+        isMunchausen(number, n / 10, total + cache(n % 10), cache)
+    else
+        number == total
+
+@main def main() =
+
+    val cache: Array[Int] = Array(0).appendedAll(
+        (1 to 9)
+            .map(_.toFloat)
+            .map(i => pow(i, i).toInt)
+    )
+
+    (0 until 440000000).foreach(i => (
+        if isMunchausen(i, i, 0, cache) then println(i)
+    ))


### PR DESCRIPTION
## How to compile/run
- Install Scala
  - The AUR only contains up to Scala 2.13. It is reccomended to install with [Coursier](https://www.scala-lang.org/download/)
- Execute via the Makefile provided or run `scala run main.scala`

## Remarks
- This implementation is slightly (~11%) slower than the other JVM languages, when running on my machine
- Using a `List[Int]` for the cache rather than an `Array[Int]` will increase runtime by > 400%
