### PR TITLE
changed to Uint32

### DIFF
--- a/mojo/main.mojo
+++ b/mojo/main.mojo
@@ -11,21 +11,21 @@ How to compile/run:
 
 alias N = 440_000_000
 
-fn is_munchausen(number: Int, cache: List[Int]) -> Bool:
+fn is_munchausen(number: UInt32, cache: List[UInt32]) -> Bool:
     n = number
-    total = 0
+    var total: UInt32 = 0
 
     while n > 0:
         digit = n % 10
-        total += cache[digit]
+        total += cache[int(digit)]
         if total > number:
             return False
         n //= 10
 
     return total == number
 
-fn get_cache() -> List[Int]:
-    ca = List[Int](capacity=10)
+fn get_cache() -> List[UInt32]:
+    ca = List[UInt32](capacity=10)
     ca.append(0)
 
     @parameter


### PR DESCRIPTION
Took a full second off on my M1 Max.

Before:
  Time (mean ± σ):      2.751 s ±  0.000 s    [User: 2.739 s, System: 0.012 s]
  Range (min … max):    2.751 s …  2.751 s    2 runs

After:
  Time (mean ± σ):      1.726 s ±  0.016 s    [User: 1.710 s, System: 0.009 s]
  Range (min … max):    1.715 s …  1.737 s    2 runs