### PR TITLE
add php opcache and JIT variants

### DIFF
--- a/_automation/php_with_jit.json
+++ b/_automation/php_with_jit.json
@@ -1,0 +1,19 @@
+{
+    "section_name": "PHP",
+    "compilers": [
+        "php"
+    ],
+    "output_file": "--",
+    "table_headers": [
+        "Execution",
+        "Runtime (sec)",
+        "--",
+        "--"
+    ],
+    "special": [
+        {
+            "compile": "--",
+            "run": "run3"
+        }
+    ]
+}

--- a/_automation/php_with_opcache.json
+++ b/_automation/php_with_opcache.json
@@ -1,0 +1,19 @@
+{
+    "section_name": "PHP",
+    "compilers": [
+        "php"
+    ],
+    "output_file": "--",
+    "table_headers": [
+        "Execution",
+        "Runtime (sec)",
+        "--",
+        "--"
+    ],
+    "special": [
+        {
+            "compile": "--",
+            "run": "run2"
+        }
+    ]
+}

--- a/php/Makefile
+++ b/php/Makefile
@@ -1,2 +1,8 @@
 run1:
 	php main.php
+
+run2:
+	php -dopcache.enable_cli=1 main.php
+
+run3:
+	php -dopcache.enable_cli=1 -dopcache.jit_buffer_size=100M main.php

--- a/php/main.php
+++ b/php/main.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 const N = 440_000_000;
 
 $cache = array_map(fn($i) => $i === 0 ? 0 : $i**$i, range(0, 9));


### PR DESCRIPTION
Raw dog PHP
```
$ time php8 main.php
0
1
3435
438579088

real	1m24,238s
user	1m24,052s
sys	0m0,014s
```

PHP with Opcache
```
$ time php8 -dopcache.enable_cli=1 main.php
0
1
3435
438579088

real	1m9,679s
user	1m9,531s
sys	0m0,021s
```

PHP with Opcache and JIT
```
$ time php8  -dopcache.enable_cli=1 -dopcache.jit_buffer_size=100M main.php
0
1
3435
438579088

real	0m30,309s
user	0m29,889s
sys	0m0,196s
```