### PR TITLE
Add Bau (transpiled to C)

### DIFF
--- a/bau/Makefile
+++ b/bau/Makefile
@@ -1,0 +1,19 @@
+transpiler:
+	-git clone git@github.com:thomasmueller/bau-lang.git
+	-git -C bau-lang pull
+	mvn -f bau-lang -DskipTests clean install
+
+v1:
+	java -jar bau-lang/target/bau-*.jar main.bau
+	gcc -O3 main.c -o main
+
+strip:
+	strip -s main
+
+run:
+	./main
+
+clean:
+	rm -f main.c
+	rm -f main
+	rm -rf bau-lang

--- a/bau/README.txt
+++ b/bau/README.txt
@@ -1,0 +1,14 @@
+Usage:
+
+make transpiler
+     Initial download, updates, and builds the transpiler, from Github
+     This requires Java and Maven
+
+make v1
+     Transpile to C, and compile the C version
+
+make run
+     Run the program
+
+make clean
+     Removes all files, including the transpiler

--- a/bau/main.bau
+++ b/bau/main.bau
@@ -1,0 +1,31 @@
+fun main()
+    for i := until(LIMIT)
+        if isMunchausen(i)
+            println(i)
+
+fun getCache() const int[]
+    result : int[10]
+    result[0] = 0
+    for i := range(1, 10)
+        result[i] = pow(i, i)
+    return result
+
+fun pow(a int, b int) const int
+    result := 1
+    for i := until(b)
+        result *= a
+    return result
+
+fun isMunchausen(number int) int
+    n := number
+    total := 0
+    while n > 0
+        digit : n % 10
+        total += cache[digit]!
+        if total > number
+            return 0
+        n = n / 10
+    return total = number
+
+LIMIT : 440_000_000
+cache : getCache()


### PR DESCRIPTION
Bau is a new language (https://github.com/thomasmueller/bau-lang).
It transpiles to C. But unlike C, it is memory-safe, so array bounds are checked,
either at runtime, or at compile time. In this case, they are checked at compile time.
(The C source code is somewhat readable actually.)

The cache is built at compile time. I added a integer "pow" function 
because the regular one (from C) is not available at compile time.
If you don't like this, then I can change it to build it at runtime.

Right not, the transpiler is written in Java, which complicates things a bit.
I have added "make transpiler" to download, update, and build the transpiler.
