### PR TITLE
Add a faster chez scheme implementation

### DIFF
--- a/scheme/Makefile
+++ b/scheme/Makefile
@@ -27,5 +27,8 @@ v6:
 run6:
 	./main
 
+run7:
+	chez --optimize-level 3 -q --script main_chez_optimized.scm
+
 clean:
 	rm main main.db main.o1

--- a/scheme/main_chez_optimized.scm
+++ b/scheme/main_chez_optimized.scm
@@ -1,0 +1,30 @@
+;(define MAX-N 10000)
+(define MAX-N 440000000)
+
+(define cache
+  (list->fxvector
+    (cons
+      0
+      (let loop ((i 1))
+        (if (> i 10)
+          '()
+          (cons (expt i i)
+                (loop (+ i 1))))))))
+
+(define (munchausen? num)
+  (let loop ((n num)
+             (total 0))
+    (cond ((fx> total num) #f)
+          ((fx> n 0)
+            (loop (fxquotient n 10)
+                  (fx+ total
+                     (fxvector-ref cache
+                                 (fxremainder n 10)))))
+          (else (fx= num total)))))
+
+(let loop ((i 0))
+  (when (munchausen? i)
+    (display i)
+    (newline))
+  (when (fx< i MAX-N)
+    (loop (fx+ i 1))))


### PR DESCRIPTION
Add a faster chez scheme implementation using fixnum operations. This version only works in chez scheme, so I named the file "main_chez_optimized.scm", not "main2.scm".

On my laptop it runs in 15 seconds, and the original implementation runs in 24 seconds.

Also, the --compile-imported-libraries flag is not necessary. It doesn't do anything since the program does not load any libraries.
